### PR TITLE
Add custom "permissions" claim to JWT token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # urlradar - Secure & Seamless URL Redirection Service
 
+**For a detailed understanding of the project's direction and planned features, please refer to the open issues.**
+
 ## Overview
 
 **Secure and Up-to-Date Links for Professionals**
@@ -205,7 +207,7 @@ an HTTP `GET` request to the desired endpoint, passing the token as a Bearer tok
 #### Example `curl` Command:
 
 ```bash
-curl -v http://localhost:8080/api/v1/hello -H "Authorization: Bearer <your-jwt-token>"
+curl -v http://localhost:8080/api/v1/principal -H "Authorization: Bearer <your-jwt-token>"
 ```
 
 ---

--- a/src/main/java/com/github/rblessings/security/JWTAuthentication.java
+++ b/src/main/java/com/github/rblessings/security/JWTAuthentication.java
@@ -1,0 +1,33 @@
+package com.github.rblessings.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * This class represents a custom authentication token that holds the value of custom claims (e.g., permissions)
+ * from the access token’s body. It extends {@link JwtAuthenticationToken} to provide additional application-specific
+ * details that can be used for authorization purposes.
+ * <p>
+ * By adding these details directly to the authentication object in the security context, you can simplify authorization
+ * configuration across your application. This makes it easier to apply these permissions either at the endpoint level
+ * or method level, depending on your security configuration.
+ * <p>
+ * This class can be extended to include other custom claims or details as needed for more complex authorization logic.
+ */
+public class JWTAuthentication extends JwtAuthenticationToken {
+    private final List<String> permissions;
+
+    public JWTAuthentication(Jwt jwt, Collection<? extends GrantedAuthority> authorities, List<String> permissions) {
+        super(jwt, authorities);
+        this.permissions = Objects.requireNonNull(permissions, "permissions should not be null");
+    }
+
+    public List<String> getPermissions() {
+        return permissions;
+    }
+}

--- a/src/main/java/com/github/rblessings/security/JwtAuthenticationConverter.java
+++ b/src/main/java/com/github/rblessings/security/JwtAuthenticationConverter.java
@@ -1,0 +1,43 @@
+package com.github.rblessings.security;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * This class converts a JWT token into a custom {@link JWTAuthentication} object.
+ * <p>
+ * The conversion process extracts necessary claims (e.g., "permissions") from the JWT
+ * and maps them to a custom authentication object that can be used for authorization purposes.
+ * <p>
+ * In a real-world scenario, you'd typically derive the authorities (e.g., roles, permissions)
+ * either directly from the access token (if they are managed at the authorization server level)
+ * or dynamically from a database or other third-party system (if they are managed from a business perspective).
+ * <p>
+ * Authorities represent what the user can do in the system (e.g., "read", "write"), and they are crucial for
+ * authorization decisions. The JWT may include a custom claim for these authorities, or they might need to be
+ * queried based on information in the JWT (such as a user identifier).
+ * <p>
+ * For the permissions, they are currently being extracted from the JWT's custom claim ("permissions").
+ * The authority values should also ideally be set in the authentication object based on this information,
+ * enabling granular access control based on the user's roles and permissions.
+ */
+@Component
+public class JwtAuthenticationConverter implements Converter<Jwt, JWTAuthentication> {
+
+    @Override
+    public JWTAuthentication convert(Jwt source) {
+        // TODO: Dynamically query authorities (roles/permissions) for the user or client from the database
+        //  or another service. In this example, we assume a static "read" authority for simplicity.
+        List<GrantedAuthority> authorities = List.of(() -> "read");
+
+        List<String> permissions = source.getClaim("permissions");
+
+        return new JWTAuthentication(source, authorities, permissions);
+    }
+}
+
+

--- a/src/main/java/com/github/rblessings/security/PrincipalRestController.java
+++ b/src/main/java/com/github/rblessings/security/PrincipalRestController.java
@@ -1,0 +1,36 @@
+package com.github.rblessings.security;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * This REST controller exposes an endpoint to retrieve the current authenticated principal
+ * from the security context. The principal typically represents the currently authenticated
+ * user or client, and the `Authentication` object contains information about the user, including
+ * authorities, credentials, and custom claims (e.g., permissions).
+ * <p>
+ * This can be useful for debugging, user profile management, or providing application-specific
+ * information about the authenticated user.
+ */
+@RestController
+@RequestMapping(value = "/api/v1/principal")
+public class PrincipalRestController {
+
+    /**
+     * This endpoint returns the current authenticated principal in the form of an {@link Authentication} object.
+     * The {@link Authentication} object contains details such as the username, authorities (roles/permissions),
+     * and any custom claims (e.g., "permissions" or user-specific data) from the JWT or security context.
+     *
+     * @param authentication The current {@link Authentication} object from the security context,
+     *                       which is automatically injected by Spring Security.
+     * @return A {@link ResponseEntity} containing the {@link Authentication} object.
+     */
+    @GetMapping
+    public ResponseEntity<Authentication> getPrincipal(Authentication authentication) {
+        return ResponseEntity.ok(authentication);
+    }
+}
+


### PR DESCRIPTION
- Modify the authorization server to include the "permissions" custom claim in the access token.
- Update the resource server to extract the "permissions" claim and store it in the security context.
- Implement an authorization rule that utilizes the "permissions" claim for access control.