### PR TITLE
feat: enable user account creation via client credentials

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.apache.kafka:kafka-streams'
     implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.session:spring-session-data-redis'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/github/rblessings/users/ApiResponse.java
+++ b/src/main/java/com/github/rblessings/users/ApiResponse.java
@@ -1,0 +1,132 @@
+package com.github.rblessings.users;
+
+import java.util.HashMap;
+import java.util.Objects;
+
+/**
+ * A standardized wrapper for API responses.
+ * <p>
+ * Provides a consistent response structure for all API responses, encapsulating:
+ * <ul>
+ *   <li><strong>message</strong>: A human-readable message indicating the result of the operation. (mostly used in error situations)</li>
+ *   <li><strong>statusCode</strong>: The HTTP status code associated with the response.</li>
+ *   <li><strong>data</strong>: The actual data of the response, which can be any type (e.g., the created user data).</li>
+ * </ul>
+ * <p>
+ * This class is immutable and thread-safe, ensuring consistency in multithreaded environments.
+ * </p>
+ */
+public final class ApiResponse<T> {
+    private final int statusCode;
+    private final String message;
+    private final T data;
+
+    private ApiResponse(int statusCode, String message, T data) {
+        if (statusCode < 100 || statusCode > 599) {
+            throw new IllegalArgumentException("Invalid HTTP status code: " + statusCode);
+        }
+        this.statusCode = statusCode;
+        this.message = message;
+        this.data = data;
+    }
+
+    /**
+     * Returns the HTTP status code of the response.
+     *
+     * @return the HTTP status code
+     */
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    /**
+     * Returns the message associated with the response.
+     *
+     * @return a human-readable message or {@code null} if none is provided
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * Returns the data of the response.
+     *
+     * @return the response data or {@code null} if none is provided
+     */
+    public T getData() {
+        return data;
+    }
+
+    /**
+     * Creates a success response with the provided HTTP status code and data.
+     *
+     * @param statusCode the HTTP status code
+     * @param data       the response data
+     * @param <T>        the type of the response data
+     * @return a new {@code ApiResponse} instance representing a success response
+     */
+    public static <T> ApiResponse<T> success(int statusCode, T data) {
+        if (data == null) {
+            throw new IllegalArgumentException("Success response data cannot be null");
+        }
+        return new ApiResponse<>(statusCode, null, data);
+    }
+
+    /**
+     * Creates an error response with the provided HTTP status code and message.
+     *
+     * @param statusCode the HTTP status code
+     * @param message    a human-readable error message
+     * @param <T>        the type of the response data (use {@code Void} if no data is required)
+     * @return a new {@code ApiResponse} instance representing an error response
+     */
+    public static <T> ApiResponse<T> error(int statusCode, String message) {
+        if (message == null || message.isEmpty()) {
+            throw new IllegalArgumentException("Error response message cannot be null or empty");
+        }
+        return new ApiResponse<>(statusCode, message, null);
+    }
+
+    /**
+     * Defines equality based on {@code statusCode}, {@code message}, and {@code data}.
+     * Ensures logical equivalence when used in collections or other frameworks requiring consistency.
+     *
+     * @param o the object to compare with
+     * @return {@code true} if logically equivalent, {@code false} otherwise
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        ApiResponse<?> that = (ApiResponse<?>) o;
+        return statusCode == that.statusCode &&
+                Objects.equals(message, that.message) &&
+                Objects.equals(data, that.data);
+    }
+
+    /**
+     * Returns a hash code consistent with {@code equals}.
+     * Necessary for proper behavior in hash-based collections like {@link HashMap}.
+     *
+     * @return the hash code of this {@code ApiResponse}
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(statusCode, message, data);
+    }
+
+    /**
+     * Provides a string representation for debugging.
+     * Useful for inspecting key fields, but may be verbose for complex {@code data}.
+     *
+     * @return a string representation of this {@code ApiResponse}
+     */
+    @Override
+    public String toString() {
+        return "ApiResponse{" +
+                "statusCode=" + statusCode +
+                ", message='" + message + '\'' +
+                ", data=" + data +
+                '}';
+    }
+}
+

--- a/src/main/java/com/github/rblessings/users/EmailAlreadyInUseException.java
+++ b/src/main/java/com/github/rblessings/users/EmailAlreadyInUseException.java
@@ -1,0 +1,39 @@
+package com.github.rblessings.users;
+
+/**
+ * Exception thrown when attempting to register or use an email that is already in use.
+ * <p>
+ * This exception is thrown during user registration or email update processes if the email
+ * is already associated with an existing user in the system. It ensures that each user has a
+ * unique email address.
+ * </p>
+ * <p>
+ * Example scenario:
+ * <pre>
+ *   if (userService.isEmailTaken(newUser.getEmail())) {
+ *       throw new EmailAlreadyInUseException(newUser.getEmail());
+ *   }
+ * </pre>
+ * </p>
+ */
+public final class EmailAlreadyInUseException extends RuntimeException {
+
+    /**
+     * Constructs a new exception with a detailed message indicating the email is already in use.
+     *
+     * @param email The email address that is already in use.
+     */
+    public EmailAlreadyInUseException(String email) {
+        super(String.format("The email address '%s' is already in use.", email));
+    }
+
+    /**
+     * Constructs a new exception with a detailed message and the specified cause.
+     *
+     * @param email The email address that is already in use.
+     * @param cause The cause of the exception, if any.
+     */
+    public EmailAlreadyInUseException(String email, Throwable cause) {
+        super(String.format("The email address '%s' is already in use.", email), cause);
+    }
+}

--- a/src/main/java/com/github/rblessings/users/User.java
+++ b/src/main/java/com/github/rblessings/users/User.java
@@ -1,0 +1,58 @@
+package com.github.rblessings.users;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.Objects;
+
+/**
+ * Represents a user in the system.
+ * Immutability ensures thread-safety, and email is the unique identity key for comparisons.
+ *
+ * <p>Key design decisions:</p>
+ * <ul>
+ *     <li><strong>Immutability:</strong> Ensures predictable, thread-safe behavior.</li>
+ *     <li><strong>Email as Identity:</strong> Uniqueness is based on email, minimizing errors in comparisons and storage.</li>
+ * </ul>
+ *
+ * <p>Password security is handled externally, but it is sensitive and should be treated securely.</p>
+ *
+ * @param id        The unique identifier for relational mapping.
+ * @param firstName The user’s first name.
+ * @param lastName  The user’s last name.
+ * @param email     The user’s email, used as the identity key.
+ * @param password  The user’s password (securely handled externally).
+ */
+@Document(collection = "users")
+public record User(
+        @Id String id,
+        String firstName,
+        String lastName,
+        String email,
+        String password) {
+
+    /**
+     * Equality is based solely on the email to ensure uniqueness and avoid issues with mutable fields.
+     *
+     * @param o The object to compare.
+     * @return {@code true} if both users have the same email.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return Objects.equals(email, user.email);
+    }
+
+    /**
+     * Hash code is derived from email for consistent behavior in hash-based collections.
+     *
+     * @return The user's email hash code.
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(email);
+    }
+}
+
+

--- a/src/main/java/com/github/rblessings/users/UserDTO.java
+++ b/src/main/java/com/github/rblessings/users/UserDTO.java
@@ -1,0 +1,29 @@
+package com.github.rblessings.users;
+
+import java.util.Objects;
+
+public record UserDTO(
+        String id,
+        String firstName,
+        String lastName,
+        String email,
+        String password
+) {
+
+    public static UserDTO from(final User user) {
+        Objects.requireNonNull(user);
+        return new UserDTO(user.id(), user.firstName(), user.lastName(), user.email(), user.password());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        UserDTO userDTO = (UserDTO) o;
+        return Objects.equals(email, userDTO.email);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(email);
+    }
+}

--- a/src/main/java/com/github/rblessings/users/UserExceptionHandler.java
+++ b/src/main/java/com/github/rblessings/users/UserExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.github.rblessings.users;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Global exception handler for all user-related exceptions thrown by REST controllers.
+ * <p>
+ * This class ensures that all errors are consistently formatted using the {@link ApiResponse}.
+ * </p>
+ */
+@RestControllerAdvice
+public class UserExceptionHandler {
+
+    /**
+     * Handles the {@link EmailAlreadyInUseException} exception and returns a standardized response.
+     *
+     * @param ex The exception that was thrown.
+     * @return A standardized API response with the error message.
+     */
+    @ExceptionHandler(EmailAlreadyInUseException.class)
+    public ResponseEntity<ApiResponse<String>> handleEmailAlreadyInUse(EmailAlreadyInUseException ex) {
+        ApiResponse<String> response = ApiResponse.error(HttpStatus.BAD_REQUEST.value(), ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * Handles all other exceptions and returns a generic error response.
+     *
+     * @param ex The exception that was thrown.
+     * @return A standardized API response with a generic error message.
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<String>> handleException(Exception ex) {
+        ApiResponse<String> response = ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}
+

--- a/src/main/java/com/github/rblessings/users/UserRegistrationRequest.java
+++ b/src/main/java/com/github/rblessings/users/UserRegistrationRequest.java
@@ -1,0 +1,23 @@
+package com.github.rblessings.users;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UserRegistrationRequest(
+        @NotBlank(message = "First name is required")
+        String firstName,
+
+        @NotBlank(message = "Last name is required")
+        String lastName,
+
+        @Email(message = "Email should be valid")
+        @NotBlank(message = "Email is required")
+        String email,
+
+        @NotBlank(message = "Password is required")
+        @Size(min = 8, message = "Password must be at least 8 characters")
+        String password
+) {
+
+}

--- a/src/main/java/com/github/rblessings/users/UserRepository.java
+++ b/src/main/java/com/github/rblessings/users/UserRepository.java
@@ -1,0 +1,9 @@
+package com.github.rblessings.users;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends MongoRepository<User, String> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/github/rblessings/users/UserService.java
+++ b/src/main/java/com/github/rblessings/users/UserService.java
@@ -1,0 +1,73 @@
+package com.github.rblessings.users;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    /**
+     * Registers a new user.
+     * <p>
+     * Checks if the provided email is already in use. If so, throws an {@link EmailAlreadyInUseException}.
+     * Otherwise, the user's details are saved after encoding the password, and a {@link UserDTO} is returned.
+     * </p>
+     *
+     * @param firstName The user's first name.
+     * @param lastName  The user's last name.
+     * @param email     The user's email address. Must be unique.
+     * @param password  The user's raw password, which will be encoded before saving.
+     * @return A {@link UserDTO} representing the registered user.
+     * @throws EmailAlreadyInUseException if the email is already registered.
+     */
+    @Transactional
+    public UserDTO registerUser(String firstName, String lastName, String email, String password) {
+        userRepository.findByEmail(email)
+                .ifPresent(user -> {
+                    throw new EmailAlreadyInUseException(user.email());
+                });
+
+        String encodedPassword = passwordEncoder.encode(password);
+
+        User user = new User(null, firstName, lastName, email, encodedPassword);
+        return UserDTO.from(userRepository.save(user));
+    }
+
+    /**
+     * Retrieves a user by their email.
+     * <p>
+     * Searches for a user using the provided email. If found, returns the corresponding {@link UserDTO}.
+     * If not found, returns {@link Optional#empty()}.
+     * </p>
+     *
+     * @param email The email address of the user.
+     * @return An {@link Optional} containing the {@link UserDTO} if found, {@link Optional#empty()} otherwise.
+     */
+    public Optional<UserDTO> findByEmail(String email) {
+        return userRepository.findByEmail(email).map(UserDTO::from);
+    }
+
+    /**
+     * Retrieves a user by their ID.
+     * <p>
+     * Searches for a user using the provided ID. If found, returns the corresponding {@link UserDTO}.
+     * If not found, returns {@link Optional#empty()}.
+     * </p>
+     *
+     * @param id The unique ID of the user.
+     * @return An {@link Optional} containing the {@link UserDTO} if found, {@link Optional#empty()} otherwise.
+     */
+    public Optional<UserDTO> findById(String id) {
+        return userRepository.findById(id).map(UserDTO::from);
+    }
+}

--- a/src/main/java/com/github/rblessings/users/UsersApiController.java
+++ b/src/main/java/com/github/rblessings/users/UsersApiController.java
@@ -1,0 +1,48 @@
+package com.github.rblessings.users;
+
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/v1/users")
+public class UsersApiController {
+    private final UserService userService;
+
+    public UsersApiController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<UserDTO>> createUser(@Valid @RequestBody UserRegistrationRequest re) {
+        UserDTO createdUser = userService.registerUser(re.firstName(), re.lastName(), re.email(), re.password());
+
+        // Build the URI for the newly created user resource using ServletUriComponentsBuilder
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(createdUser.id())
+                .toUri();
+
+        // Create a response object using the generic ApiResponse
+        ApiResponse<UserDTO> response = ApiResponse.success(HttpStatus.CREATED.value(), createdUser);
+
+        // Response with Location header and body
+        return ResponseEntity.created(location).body(response);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<UserDTO>> getUserById(@PathVariable String id) {
+        return userService.findById(id)
+                .map(user -> ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), user)))
+                .orElseGet(() -> {
+                    var notFoundStatus = HttpStatus.NOT_FOUND;
+                    return ResponseEntity.status(notFoundStatus).body(ApiResponse.error(notFoundStatus.value(),
+                            "User with ID %s not found".formatted(id)));
+                });
+    }
+}

--- a/src/test/java/com/github/rblessings/security/SecurityConfigurationTest.java
+++ b/src/test/java/com/github/rblessings/security/SecurityConfigurationTest.java
@@ -50,10 +50,10 @@ class SecurityConfigurationTest {
 
     @Test
     void shouldGenerateJwtTokenForValidClientCredentials() {
-        // Given valid client credentials
+        // Given: Valid client credentials
         String encodedCredentials = encodeClientCredentials(CLIENT_ID, CLIENT_SECRET);
 
-        // When requesting the token
+        // When: Requesting the token with valid credentials
         webTestClient.post()
                 .uri(TOKEN_ENDPOINT)
                 .header(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded")
@@ -64,18 +64,18 @@ class SecurityConfigurationTest {
                 .expectBody()
                 .consumeWith(response -> {
                     String responseBody = getResponseBodyContent(response);
-                    // Validate token response structure
+                    // Then: Assert the response body contains a valid token
                     assertTokenResponse(responseBody);
                 });
     }
 
     @Test
     void shouldReturnUnauthorizedForInvalidClientCredentials() {
-        // Given invalid client credentials
+        // Given: Invalid client credentials
         String invalidClientId = "invalidClient";
         String invalidClientSecret = "invalidSecret";
 
-        // When requesting the token with invalid credentials
+        // When: Requesting the token with invalid credentials
         webTestClient.post()
                 .uri(TOKEN_ENDPOINT)
                 .header(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded")
@@ -84,6 +84,7 @@ class SecurityConfigurationTest {
                 .expectStatus().isUnauthorized()
                 .expectBody()
                 .consumeWith(response -> {
+                    // Then: should not be able to retrieve a token
                     String responseBody = getResponseBodyContent(response);
                     assertThat(responseBody).contains("invalid_client");
                 });
@@ -214,7 +215,11 @@ class SecurityConfigurationTest {
         return accessToken.get();
     }
 
-    // Endpoint to test the OAuth 2 resource server configuration
+    /**
+     * A test controller used to verify the OAuth 2 Resource Server configuration.
+     * This controller exposes a simple endpoint that can be accessed by clients
+     * with valid access tokens.
+     */
     @RestController
     @RequestMapping(value = "/api/v1/hello")
     static class TestApiController {

--- a/src/test/java/com/github/rblessings/users/UserServiceTest.java
+++ b/src/test/java/com/github/rblessings/users/UserServiceTest.java
@@ -1,0 +1,75 @@
+package com.github.rblessings.users;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+
+    private User user;
+
+    @BeforeEach
+    public void setUp() {
+        // Prepare test data
+        user = new User("1", "John", "Doe", "john.doe@example.com", "encodedPassword");
+    }
+
+    @Test
+    public void testRegisterUser_EmailAlreadyInUse() {
+        // Arrange: Mock the behavior of the repository to return a user when searching by email
+        String email = "john.doe@example.com";
+        when(userRepository.findByEmail(email)).thenReturn(java.util.Optional.of(user));
+
+        // Act & Assert: Expect EmailAlreadyInUseException to be thrown
+        EmailAlreadyInUseException exception = assertThrows(EmailAlreadyInUseException.class, () -> {
+            userService.registerUser("John", "Doe", email, "password123");
+        });
+
+        // Assert: Check that the exception message is correct
+        assertEquals("The email address 'john.doe@example.com' is already in use.", exception.getMessage());
+
+        // Verify the userRepository was called with the correct email
+        verify(userRepository).findByEmail(email);
+    }
+
+    @Test
+    public void testRegisterUser_Success() {
+        // Arrange: Mock the repository to return empty (no user found for the email)
+        String email = "john.doe@example.com";
+        when(userRepository.findByEmail(email)).thenReturn(java.util.Optional.empty());
+
+        // Mock the password encoding behavior
+        when(passwordEncoder.encode("password123")).thenReturn("encodedPassword");
+
+        // Mock the saving of a new user
+        when(userRepository.save(any(User.class))).thenReturn(user);
+
+        // Act: Call the registerUser method
+        UserDTO result = userService.registerUser("John", "Doe", email, "password123");
+
+        // Assert: Check that the result is not null and the email matches
+        assertNotNull(result);
+        assertEquals("john.doe@example.com", result.email());
+
+        // Verify interactions with the repository
+        verify(userRepository).findByEmail(email);
+        verify(userRepository).save(any(User.class));
+    }
+}

--- a/src/test/java/com/github/rblessings/users/UsersApiControllerTest.java
+++ b/src/test/java/com/github/rblessings/users/UsersApiControllerTest.java
@@ -1,0 +1,102 @@
+package com.github.rblessings.users;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UsersApiControllerTest {
+
+    private MockMvc mockMvc;
+
+    @InjectMocks
+    private UsersApiController usersApiController;
+
+    @Mock
+    private UserService userService;
+
+    private UserRegistrationRequest validUserRequest;
+    private UserDTO mockUserDTO;
+
+    @BeforeEach
+    public void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(usersApiController).build();
+
+        validUserRequest = new UserRegistrationRequest("John", "Doe", "john.doe@example.com", "password123");
+        mockUserDTO = new UserDTO("1", "John", "Doe", "john.doe@example.com", "secret");
+    }
+
+    @Test
+    public void testCreateUser_Success() throws Exception {
+        // Arrange
+        when(userService.registerUser(validUserRequest.firstName(), validUserRequest.lastName(), validUserRequest.email(), validUserRequest.password()))
+                .thenReturn(mockUserDTO);
+
+        URI location = ServletUriComponentsBuilder
+                .fromPath("/api/v1/users/{id}")
+                .buildAndExpand(mockUserDTO.id())
+                .toUri();
+
+        // Act and Assert
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"firstName\": \"John\", \"lastName\": \"Doe\", \"email\": \"john.doe@example.com\", \"password\": \"password123\"}")
+                )
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, "http://localhost%s".formatted(location.getPath())))
+                .andExpect(jsonPath("$.statusCode").value(HttpStatus.CREATED.value()))
+                .andExpect(jsonPath("$.data.id").value(mockUserDTO.id()))
+                .andExpect(jsonPath("$.data.firstName").value(mockUserDTO.firstName()))
+                .andExpect(jsonPath("$.data.lastName").value(mockUserDTO.lastName()))
+                .andExpect(jsonPath("$.data.email").value(mockUserDTO.email()));
+    }
+
+    @Test
+    public void testGetUserById_Success() {
+        // Arrange
+        when(userService.findById("1")).thenReturn(Optional.of(mockUserDTO));
+
+        ApiResponse<UserDTO> expectedResponse = ApiResponse.success(HttpStatus.OK.value(), mockUserDTO);
+
+        // Act
+        ResponseEntity<ApiResponse<UserDTO>> responseEntity = usersApiController.getUserById("1");
+
+        // Assert
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(responseEntity.getBody()).isEqualTo(expectedResponse);
+    }
+
+    @Test
+    public void testGetUserById_NotFound() {
+        // Arrange
+        when(userService.findById("2")).thenReturn(Optional.empty());
+
+        ApiResponse<String> expectedResponse = ApiResponse.error(HttpStatus.NOT_FOUND.value(),
+                "User with ID 2 not found");
+
+        // Act
+        ResponseEntity<ApiResponse<UserDTO>> responseEntity = usersApiController.getUserById("2");
+
+        // Assert
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(responseEntity.getBody()).isEqualTo(expectedResponse);
+    }
+}


### PR DESCRIPTION
- Implemented functionality allowing the client credentials-based client app to authenticate and obtain a token.
- The obtained token is then used to create a user account through the /api/v1/users endpoint.
- This supports automated user account creation in a backend service context using machine-to-machine authentication.