### PR TITLE
feat: migrate backend to reactive spring webflux

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,36 +19,38 @@ repositories {
 }
 
 ext {
-    set('springCloudVersion', "2024.0.0")
     set('snippetsDir', file("build/generated-snippets"))
+    set('springCloudVersion', "2024.0.0")
 }
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
-    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.apache.kafka:kafka-streams'
-    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.apache.kafka:kafka-streams'
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
+    implementation 'org.springframework.cloud:spring-cloud-stream'
+    implementation 'org.springframework.cloud:spring-cloud-stream-binder-kafka'
+    implementation 'org.springframework.cloud:spring-cloud-stream-binder-kafka-streams'
+    implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springframework.session:spring-session-data-redis'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-    testImplementation 'org.springframework.kafka:spring-kafka-test'
     testImplementation 'io.projectreactor:reactor-test'
-    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.springframework.cloud:spring-cloud-stream-test-binder'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-webtestclient'
+    testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.testcontainers:mongodb'
-    testImplementation 'org.springframework.security:spring-security-test'
-    testImplementation 'org.testcontainers:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-webtestclient'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 dependencyManagement {
@@ -74,7 +76,8 @@ tasks.named("bootJar") {
     dependsOn("asciidoctor")
 }
 
-tasks.named("bootBuildImage") {
+tasks.named('bootBuildImage') {
+    builder = 'paketobuildpacks/builder-jammy-base:latest'
     imageName = "rblessings/urlradar"
     environment = ["BP_JVM_VERSION": "23.*"]
 }

--- a/src/main/java/com/github/rblessings/security/SecurityConfiguration.java
+++ b/src/main/java/com/github/rblessings/security/SecurityConfiguration.java
@@ -2,39 +2,48 @@ package com.github.rblessings.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.MediaType;
-import org.springframework.security.config.Customizer;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationEntryPoint;
-import org.springframework.security.oauth2.server.resource.web.access.BearerTokenAccessDeniedHandler;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
+import org.springframework.security.oauth2.server.resource.web.access.server.BearerTokenServerAccessDeniedHandler;
+import org.springframework.security.oauth2.server.resource.web.server.BearerTokenServerAuthenticationEntryPoint;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.util.matcher.PathPatternParserServerWebExchangeMatcher;
 
-import static org.springframework.security.oauth2.core.authorization.OAuth2AuthorizationManagers.hasScope;
+import static org.springframework.security.config.Customizer.withDefaults;
+import static org.springframework.security.oauth2.core.authorization.OAuth2ReactiveAuthorizationManagers.hasScope;
 
 @Configuration
-@EnableWebSecurity
+@EnableWebFluxSecurity
 public class SecurityConfiguration {
 
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     @Bean
-    public SecurityFilterChain resourceServerSecurityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityWebFilterChain apiHttpSecurity(ServerHttpSecurity http) {
         http
-                .authorizeHttpRequests((authorize) -> authorize
-                        .requestMatchers("/actuator/**").permitAll()
-                        .requestMatchers("/api/v1/**").access(hasScope("apis:read"))
-                        .anyRequest().authenticated()
+                .securityMatcher(new PathPatternParserServerWebExchangeMatcher("/api/**"))
+                .authorizeExchange(exchanges -> exchanges
+                        .pathMatchers("/api/v1/**").access(hasScope("apis:read"))
+                        .anyExchange().authenticated()
                 )
-                .oauth2ResourceServer((oauth2) -> oauth2
-                        .jwt(Customizer.withDefaults()))
-                .exceptionHandling((exceptions) -> exceptions
-                        .defaultAuthenticationEntryPointFor(
-                                new BearerTokenAuthenticationEntryPoint(),
-                                new MediaTypeRequestMatcher(MediaType.ALL)
-                        )
-                        .accessDeniedHandler(new BearerTokenAccessDeniedHandler()));
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(withDefaults()))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(new BearerTokenServerAuthenticationEntryPoint())
+                        .accessDeniedHandler(new BearerTokenServerAccessDeniedHandler())
+                );
+        return http.build();
+    }
+
+    @Bean
+    SecurityWebFilterChain webHttpSecurity(ServerHttpSecurity http) {
+        http
+                .authorizeExchange(exchanges -> exchanges
+                        .pathMatchers("/actuator/**").permitAll()
+                        .anyExchange().authenticated()
+                );
         return http.build();
     }
 
@@ -43,3 +52,4 @@ public class SecurityConfiguration {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }
+

--- a/src/main/java/com/github/rblessings/users/ApiResponse.java
+++ b/src/main/java/com/github/rblessings/users/ApiResponse.java
@@ -23,7 +23,7 @@ public final class ApiResponse<T> {
 
     private ApiResponse(int statusCode, String message, T data) {
         if (statusCode < 100 || statusCode > 599) {
-            throw new IllegalArgumentException("Invalid HTTP status code: " + statusCode);
+            throw new IllegalArgumentException(String.format("Invalid HTTP status code: %d", statusCode));
         }
         this.statusCode = statusCode;
         this.message = message;

--- a/src/main/java/com/github/rblessings/users/UserDTO.java
+++ b/src/main/java/com/github/rblessings/users/UserDTO.java
@@ -10,7 +10,7 @@ public record UserDTO(
         String password
 ) {
 
-    public static UserDTO from(final User user) {
+    public static UserDTO from(final UserEntity user) {
         Objects.requireNonNull(user);
         return new UserDTO(user.id(), user.firstName(), user.lastName(), user.email(), user.password());
     }

--- a/src/main/java/com/github/rblessings/users/UserEntity.java
+++ b/src/main/java/com/github/rblessings/users/UserEntity.java
@@ -24,7 +24,7 @@ import java.util.Objects;
  * @param password  The user’s password (securely handled externally).
  */
 @Document(collection = "users")
-public record User(
+public record UserEntity(
         @Id String id,
         String firstName,
         String lastName,
@@ -40,7 +40,7 @@ public record User(
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
-        User user = (User) o;
+        UserEntity user = (UserEntity) o;
         return Objects.equals(email, user.email);
     }
 

--- a/src/main/java/com/github/rblessings/users/UserExceptionHandler.java
+++ b/src/main/java/com/github/rblessings/users/UserExceptionHandler.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import reactor.core.publisher.Mono;
 
 /**
  * Global exception handler for all user-related exceptions thrown by REST controllers.
@@ -18,24 +19,26 @@ public class UserExceptionHandler {
      * Handles the {@link EmailAlreadyInUseException} exception and returns a standardized response.
      *
      * @param ex The exception that was thrown.
-     * @return A standardized API response with the error message.
+     * @return A standardized API response with the error message wrapped in a Mono.
      */
     @ExceptionHandler(EmailAlreadyInUseException.class)
-    public ResponseEntity<ApiResponse<String>> handleEmailAlreadyInUse(EmailAlreadyInUseException ex) {
-        ApiResponse<String> response = ApiResponse.error(HttpStatus.BAD_REQUEST.value(), ex.getMessage());
-        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    public Mono<ResponseEntity<ApiResponse<String>>> handleEmailAlreadyInUse(EmailAlreadyInUseException ex) {
+        final var httpStatus = HttpStatus.BAD_REQUEST;
+        ApiResponse<String> response = ApiResponse.error(httpStatus.value(), ex.getMessage());
+        return Mono.just(new ResponseEntity<>(response, httpStatus));
     }
 
     /**
      * Handles all other exceptions and returns a generic error response.
      *
      * @param ex The exception that was thrown.
-     * @return A standardized API response with a generic error message.
+     * @return A standardized API response with a generic error message wrapped in a Mono.
      */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<String>> handleException(Exception ex) {
-        ApiResponse<String> response = ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage());
-        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    public Mono<ResponseEntity<ApiResponse<String>>> handleException(Exception ex) {
+        final var httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+        ApiResponse<String> response = ApiResponse.error(httpStatus.value(), ex.getMessage());
+        return Mono.just(new ResponseEntity<>(response, httpStatus));
     }
 }
 

--- a/src/main/java/com/github/rblessings/users/UserRepository.java
+++ b/src/main/java/com/github/rblessings/users/UserRepository.java
@@ -1,9 +1,8 @@
 package com.github.rblessings.users;
 
-import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import reactor.core.publisher.Mono;
 
-import java.util.Optional;
-
-public interface UserRepository extends MongoRepository<User, String> {
-    Optional<User> findByEmail(String email);
+public interface UserRepository extends ReactiveMongoRepository<UserEntity, String> {
+    Mono<UserEntity> findByEmail(String email);
 }

--- a/src/main/java/com/github/rblessings/users/UsersApiController.java
+++ b/src/main/java/com/github/rblessings/users/UsersApiController.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
 
 import java.net.URI;
 
@@ -19,32 +20,35 @@ public class UsersApiController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse<UserDTO>> createUser(@Valid @RequestBody UserRegistrationRequest re) {
-        UserDTO createdUser = userService.registerUser(re.firstName(), re.lastName(), re.email(), re.password());
+    public Mono<ResponseEntity<ApiResponse<UserDTO>>> createUser(
+            @Valid @RequestBody Mono<UserRegistrationRequest> requestMono) {
+        return requestMono
+                .flatMap(re -> userService.registerUser(re.firstName(), re.lastName(), re.email(), re.password()))
+                .map(createdUser -> {
+                    URI location = UriComponentsBuilder
+                            .fromPath("/api/v1/users/{id}")
+                            .buildAndExpand(createdUser.id())
+                            .toUri();
 
-        URI location = ServletUriComponentsBuilder
-                .fromCurrentRequest()
-                .path("/{id}")
-                .buildAndExpand(createdUser.id())
-                .toUri();
-
-        ApiResponse<UserDTO> response = ApiResponse.success(HttpStatus.CREATED.value(), createdUser);
-        return ResponseEntity.created(location).body(response);
-    }
-
-    @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<UserDTO>> getUserById(@PathVariable String id) {
-        return userService.findById(id)
-                .map(user -> ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), user)))
-                .orElseGet(() -> {
-                    var notFoundStatus = HttpStatus.NOT_FOUND;
-                    return ResponseEntity.status(notFoundStatus).body(ApiResponse.error(notFoundStatus.value(),
-                            "User with ID %s not found".formatted(id)));
+                    ApiResponse<UserDTO> response = ApiResponse.success(HttpStatus.CREATED.value(), createdUser);
+                    return ResponseEntity.created(location).body(response);
                 });
     }
 
+    @GetMapping("/{id}")
+    public Mono<ResponseEntity<ApiResponse<UserDTO>>> getUserById(@PathVariable String id) {
+        return userService.findById(id)
+                .map(user -> ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), user)))
+                .defaultIfEmpty(ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(ApiResponse.error(HttpStatus.NOT_FOUND.value(), "User with ID %s not found".formatted(id))));
+    }
+
     @GetMapping("/principal")
-    public ResponseEntity<ApiResponse<Authentication>> getPrincipal(Authentication authentication) {
-        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), authentication));
+    public Mono<ResponseEntity<ApiResponse<Authentication>>> getPrincipal(Mono<Authentication> authenticationMono) {
+        return authenticationMono
+                .map(authentication -> {
+                    ApiResponse<Authentication> body = ApiResponse.success(HttpStatus.OK.value(), authentication);
+                    return ResponseEntity.ok(body);
+                });
     }
 }

--- a/src/test/java/com/github/rblessings/UrlradarApplicationTest.java
+++ b/src/test/java/com/github/rblessings/UrlradarApplicationTest.java
@@ -10,6 +10,6 @@ class UrlradarApplicationTest {
 
     @Test
     void contextLoads() {
-        // Verifies that the Spring application context loads without errors.
+
     }
 }


### PR DESCRIPTION
- Migrated all blocking Spring WebMVC APIs to reactive Spring WebFlux APIs.
- Updated service layer to leverage non-blocking reactive programming paradigms.
- Refactored database integration to use reactive drivers and repositories.
- Enhanced security configuration with Spring Security's reactive features.
- Improved scalability and performance by enabling end-to-end non-blocking I/O.
- Ensured compatibility with Spring Boot 3.4.1 and Java 23.
- Verified functionality with updated unit and integration tests using WebTestClient.